### PR TITLE
Update ObservableList.cs

### DIFF
--- a/Source/DarkUI/Collections/ObservableList.cs
+++ b/Source/DarkUI/Collections/ObservableList.cs
@@ -1,94 +1,133 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace DarkUI.Collections
 {
-    public class ObservableList<T> : List<T>, IDisposable
+    // A standard event args approach, with info about added or removed items
+    public class CollectionChangedEventArgs<T> : EventArgs
     {
-        #region Field Region
+        public IReadOnlyList<T> ChangedItems { get; }
+        public bool ItemsAdded { get; }
 
+        public CollectionChangedEventArgs(IReadOnlyList<T> changedItems, bool itemsAdded)
+        {
+            ChangedItems = changedItems;
+            ItemsAdded = itemsAdded;
+        }
+    }
+
+    public class ObservableList<T> : IList<T>, IDisposable
+    {
+        private readonly List<T> _internalList = new List<T>();
         private bool _disposed;
 
-        #endregion
+        public event EventHandler<CollectionChangedEventArgs<T>> CollectionChanged;
 
-        #region Event Region
-
-        public event EventHandler<ObservableListModified<T>> ItemsAdded;
-        public event EventHandler<ObservableListModified<T>> ItemsRemoved;
-
-        #endregion
-
-        #region Destructor Region
-
-        ~ObservableList()
-        {
-            Dispose(false);
-        }
-
-        #endregion
-
-        #region Dispose Region
-
+        // Dispose
         public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {
-                if (ItemsAdded != null)
-                    ItemsAdded = null;
-
-                if (ItemsRemoved != null)
-                    ItemsRemoved = null;
-
+                // Null out event subscribers
+                CollectionChanged = null;
                 _disposed = true;
+                GC.SuppressFinalize(this);
             }
         }
 
+        // We do not need a finalizer here since no unmanaged resources
+        // ~ObservableList() { ... }
+
+        // Private helper to raise event
+        private void OnCollectionChanged(IList<T> items, bool added)
+        {
+            CollectionChanged?.Invoke(this, new CollectionChangedEventArgs<T>(new List<T>(items), added));
+        }
+
+        #region IList<T> Members
+
+        public int Count => _internalList.Count;
+        public bool IsReadOnly => false;
+
+        public T this[int index]
+        {
+            get => _internalList[index];
+            set
+            {
+                var oldItem = _internalList[index];
+                _internalList[index] = value;
+                // Here, you could raise an event for removal + addition, or a single "changed" event
+                OnCollectionChanged(new List<T> { oldItem }, false);
+                OnCollectionChanged(new List<T> { value }, true);
+            }
+        }
+
+        public void Add(T item)
+        {
+            _internalList.Add(item);
+            OnCollectionChanged(new List<T> { item }, true);
+        }
+
+        public void Clear()
+        {
+            if (_internalList.Count > 0)
+            {
+                var removedItems = new List<T>(_internalList);
+                _internalList.Clear();
+                OnCollectionChanged(removedItems, false);
+            }
+        }
+
+        public bool Contains(T item) => _internalList.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _internalList.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _internalList.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool Remove(T item)
+        {
+            if (_internalList.Remove(item))
+            {
+                OnCollectionChanged(new List<T> { item }, false);
+                return true;
+            }
+            return false;
+        }
+
+        public int IndexOf(T item) => _internalList.IndexOf(item);
+
+        public void Insert(int index, T item)
+        {
+            _internalList.Insert(index, item);
+            OnCollectionChanged(new List<T> { item }, true);
+        }
+
+        public void RemoveAt(int index)
+        {
+            var oldItem = _internalList[index];
+            _internalList.RemoveAt(index);
+            OnCollectionChanged(new List<T> { oldItem }, false);
+        }
+
         #endregion
 
-        #region Method Region
-
-        public new void Add(T item)
+        // Additional methods for AddRange, RemoveRange, etc.
+        public void AddRange(IEnumerable<T> collection)
         {
-            base.Add(item);
-
-            if (ItemsAdded != null)
-                ItemsAdded(this, new ObservableListModified<T>(new List<T> { item }));
+            var list = new List<T>(collection);
+            _internalList.AddRange(list);
+            OnCollectionChanged(list, true);
         }
 
-        public new void AddRange(IEnumerable<T> collection)
+        public void RemoveRange(int index, int count)
         {
-            var list = collection.ToList();
-
-            base.AddRange(list);
-
-            if (ItemsAdded != null)
-                ItemsAdded(this, new ObservableListModified<T>(list));
+            var removedItems = _internalList.GetRange(index, count);
+            _internalList.RemoveRange(index, count);
+            OnCollectionChanged(removedItems, false);
         }
-
-        public new void Remove(T item)
-        {
-            base.Remove(item);
-
-            if (ItemsRemoved != null)
-                ItemsRemoved(this, new ObservableListModified<T>(new List<T> { item }));
-        }
-
-        public new void Clear()
-        {
-            ObservableListModified<T> removed = new ObservableListModified<T>(this.ToList<T>());
-            base.Clear();
-            
-            if (removed.Items.Count() > 0 && ItemsRemoved != null)
-                ItemsRemoved(this, removed);
-        }
-
-        #endregion
     }
 }
+


### PR DESCRIPTION
Verify Understanding
You’ve shared a C# class, ObservableList<T>, which inherits from List<T> and implements IDisposable. Its goal is to raise events (ItemsAdded and ItemsRemoved) when items are added or removed from the list. It also provides cleanup logic in Dispose() and a finalizer (~ObservableList()).

Below, I will:

Summarize key functionality and intentions.
Critique areas of concern regarding design, memory management, and best practices. Suggest refactoring approaches for maintainability and clarity.
1. High-Level Observations Inheritance from List<T>

You are extending the built-in List<T> class. This can be convenient, but there are subtle drawbacks: You expose the entire List<T> API, including methods that you may not handle with event-raising logic (e.g., Insert, InsertRange, RemoveAt, RemoveRange, Sort, Reverse, etc.). Some built-in List<T> operations do not raise your events. For example, this[3] = someValue; won’t invoke any added/removed events. A more robust approach might be to wrap an internal List<T> (composition) rather than inherit from List<T>, so you can tightly control which modifications are possible and consistently raise events. Event Handling

ItemsAdded and ItemsRemoved are raised after calls to Add, AddRange, Remove, or Clear. That’s straightforward. However, note that some inherited methods (like RemoveAll, RemoveAt, Insert, InsertRange) are not overridden. Calling these methods bypasses event raising, which may lead to an inconsistent understanding of the list’s changes. Disposal and Finalizer

You override Dispose(bool disposing) and include a finalizer (~ObservableList()). Generally, a finalizer is only needed when your class directly holds unmanaged resources (e.g., raw file handles, unmanaged memory). Here, you only have events and boolean flags. A finalizer is usually unnecessary. Disabling the events in Dispose can be acceptable, but typically events are unsubscribed by consumers. If your main goal is to prevent memory leaks from long-lived subscribers, there are alternative patterns (e.g., WeakEvent patterns, or letting the consumer handle subscription lifecycles). Also note that Dispose() is invoked manually, whereas the finalizer is invoked by the GC. If the main resource is just the event handlers, you rarely need a finalizer. Thread Safety

Currently, the list is not thread-safe. If multiple threads modify the list concurrently, events might be raised in unpredictable order, or the list might be corrupted. This may be acceptable for single-thread usage, but if you need concurrency, you’d have to add locking or concurrency primitives. Naming & API Conventions

The event arguments are named ObservableListModified<T>, but the event is named ItemsAdded or ItemsRemoved. You might rename the class to ObservableListChangedEventArgs<T> or similar for clarity. The events are typed as EventHandler<ObservableListModified<T>>. This is fine, though you might consider a more standard approach with [Something]EventArgs if you’re aligning with .NET conventions.
2. Areas for Improvement Inheritance vs. Composition

Preferred: Use composition. For example:
csharp
Copy code
public class ObservableList<T> : IDisposable
{
    private readonly List<T> _internalList = new List<T>();
    // ...
}
This way, you can implement the operations you want and raise events consistently. You avoid exposing the entire List<T> surface area that might bypass events. Cover All List Modifications

If you must inherit from List<T>, consider overriding more methods (e.g., Insert, RemoveAt, RemoveAll, InsertRange, RemoveRange, etc.) and raise the appropriate events. Otherwise, the list can change without events being raised. Alternatively, if you only need a subset of operations, composition is safer. You implement exactly the methods needed and raise events in each. Remove the Finalizer If Not Required

If you don’t manage unmanaged resources, you typically don’t need a finalizer. Instead, just implement IDisposable if you must release event references or notify subscribers. Typically, .NET objects that only hold references to managed objects (like event delegates) do not need a finalizer. The GC can clean them up. The finalizer is only beneficial if you must release unmanaged resources. Event Unsubscribe

You’re nullifying ItemsAdded and ItemsRemoved in Dispose(). This might be okay, but typically external subscribers also need to unsubscribe. If a subscriber outlives the ObservableList, references might remain. By setting them to null, you effectively remove references to the event handlers. That’s a one-sided approach, but it might suffice if your usage pattern ensures Dispose() is always called and nobody references the object afterwards. Performance Considerations

Wrapping multiple calls in AddRange or RemoveRange is good for performance, but you might end up raising a single event for the entire range. That’s usually desired. However, be mindful of how often events are raised if you’re dealing with large or frequent changes. If performance is a concern, you might add a “bulk update” mode or a “suspend notifications” pattern.
3. Illustrative Refactoring with Composition Here is a simplified example that demonstrates composition instead of inheritance, ensures events are raised for each relevant operation, and removes the finalizer. This code also merges the “added” and “removed” events into a single CollectionChanged event with more standard .NET naming and event args, although you can keep separate added/removed events if that’s more convenient.

csharp
Copy code
using System;
using System.Collections;
using System.Collections.Generic;

namespace DarkUI.Collections
{
    // A standard event args approach, with info about added or removed items
    public class CollectionChangedEventArgs<T> : EventArgs
    {
        public IReadOnlyList<T> ChangedItems { get; }
        public bool ItemsAdded { get; }

        public CollectionChangedEventArgs(IReadOnlyList<T> changedItems, bool itemsAdded)
        {
            ChangedItems = changedItems;
            ItemsAdded = itemsAdded;
        }
    }

    public class ObservableList<T> : IList<T>, IDisposable
    {
        private readonly List<T> _internalList = new List<T>();
        private bool _disposed;

        public event EventHandler<CollectionChangedEventArgs<T>> CollectionChanged;

        // Dispose
        public void Dispose()
        {
            if (!_disposed)
            {
                // Null out event subscribers
                CollectionChanged = null;
                _disposed = true;
                GC.SuppressFinalize(this);
            }
        }

        // We do not need a finalizer here since no unmanaged resources
        // ~ObservableList() { ... }

        // Private helper to raise event
        private void OnCollectionChanged(IList<T> items, bool added)
        {
            CollectionChanged?.Invoke(this, new CollectionChangedEventArgs<T>(new List<T>(items), added));
        }

        #region IList<T> Members

        public int Count => _internalList.Count;
        public bool IsReadOnly => false;

        public T this[int index]
        {
            get => _internalList[index];
            set
            {
                var oldItem = _internalList[index];
                _internalList[index] = value;
                // Here, you could raise an event for removal + addition, or a single "changed" event
                OnCollectionChanged(new List<T> { oldItem }, false);
                OnCollectionChanged(new List<T> { value }, true);
            }
        }

        public void Add(T item)
        {
            _internalList.Add(item);
            OnCollectionChanged(new List<T> { item }, true);
        }

        public void Clear()
        {
            if (_internalList.Count > 0)
            {
                var removedItems = new List<T>(_internalList);
                _internalList.Clear();
                OnCollectionChanged(removedItems, false);
            }
        }

        public bool Contains(T item) => _internalList.Contains(item);

        public void CopyTo(T[] array, int arrayIndex) => _internalList.CopyTo(array, arrayIndex);

        public IEnumerator<T> GetEnumerator() => _internalList.GetEnumerator();

        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

        public bool Remove(T item)
        {
            if (_internalList.Remove(item))
            {
                OnCollectionChanged(new List<T> { item }, false);
                return true;
            }
            return false;
        }

        public int IndexOf(T item) => _internalList.IndexOf(item);

        public void Insert(int index, T item)
        {
            _internalList.Insert(index, item);
            OnCollectionChanged(new List<T> { item }, true);
        }

        public void RemoveAt(int index)
        {
            var oldItem = _internalList[index];
            _internalList.RemoveAt(index);
            OnCollectionChanged(new List<T> { oldItem }, false);
        }

        #endregion

        // Additional methods for AddRange, RemoveRange, etc.
        public void AddRange(IEnumerable<T> collection)
        {
            var list = new List<T>(collection);
            _internalList.AddRange(list);
            OnCollectionChanged(list, true);
        }

        public void RemoveRange(int index, int count)
        {
            var removedItems = _internalList.GetRange(index, count);
            _internalList.RemoveRange(index, count);
            OnCollectionChanged(removedItems, false);
        }
    }
}
Explanation

We implement IList<T> (or ICollection<T>, depending on your needs). For every mutating operation, we manually raise CollectionChanged. We removed the finalizer (~ObservableList()) because we have no unmanaged resources. We added Dispose() to clear event subscriptions, which can help if the list is long-lived and you want to avoid references persisting. We restructured the event to pass a single argument CollectionChangedEventArgs<T>, which tells if items were added or removed (rather than separate ItemsAdded / ItemsRemoved events). You can keep them separate if that’s your preference.
4. Additional Considerations Event Flooding

If you add or remove many items in a loop, the above pattern fires an event per item. If that’s too frequent, you might prefer to group changes (e.g., call AddRange or RemoveRange). Retaining Both ItemsAdded and ItemsRemoved

If you strongly prefer separate events, you can keep ItemsAdded and ItemsRemoved but still use the composition approach. Just raise the appropriate event in each method. Thread Safety

If thread safety is a requirement, introduce locks around all modifications and raise events outside the lock to avoid potential deadlocks. This is an advanced scenario depending on your concurrency model. Finalizer

Removing the finalizer (and just using IDisposable) is a best practice if you have no unmanaged resources. Finalizers come with overhead and complexity, so they should be avoided unless necessary. Extension Points

If you want users to override certain behavior, you could make methods virtual. But for typical usage, just a sealed or standard class is fine.
5. Conclusion and Recommendations Use Composition Rather than Inheritance: This ensures that all ways of modifying the list raise your events consistently and do not expose unmonitored List<T> operations. Eliminate Unnecessary Finalizer: If you don’t manage unmanaged resources, rely on Dispose() alone or remove IDisposable entirely if you only need event unsubscribing. Consider Full API Coverage: If you keep inheriting from List<T>, override every relevant mutator (e.g., Insert, RemoveAt, etc.). Otherwise, changes can bypass your event logic. Refine Event Pattern: Use more standard naming (e.g., CollectionChanged) or keep separate events for added/removed items. Follow typical .NET patterns (EventHandler<TEventArgs> with EventArgs). With these changes, your ObservableList<T> will be more robust, consistent, and aligned with .NET best practices.