### PR TITLE
Update app.manifest

### DIFF
--- a/Source/Client/My Project/app.manifest
+++ b/Source/Client/My Project/app.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
@@ -9,7 +9,22 @@
   </trustInfo>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>
     </windowsSettings>
   </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and later -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
DPI Settings:  
Added <dpiAwareness>PerMonitorV2</dpiAwareness> for modern per-monitor DPI scaling (Windows 10+).  

Kept <dpiAware>true</dpiAware> for backward compatibility with older Windows versions.

Long Path Awareness:  
Added <longPathAware>true</longPathAware> to support file paths exceeding 260 characters.

GDI Scaling:  
Added <gdiScaling>true</gdiScaling> to improve rendering on high-DPI screens.

Compatibility:  
Added a <compatibility> section with GUIDs for Windows 7, 8, 8.1, and 10 to ensure broad OS support.

TrustInfo:  
Left unchanged as asInvoker is appropriate unless your app requires elevated privileges.