### PR TITLE
Update dotnet-tools.json

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -5,9 +5,54 @@
     "dotnet-mgcb-editor-windows": {
       "version": "3.8.2.1105",
       "commands": [
-        "mgcb-editor-windows"
+        {
+          "name": "mgcb-editor-windows",
+          "description": "Launches the MGCB Editor for Windows"
+        }
       ],
-      "rollForward": false
+      "rollForward": false,
+      "options": {
+        "verbose": true,
+        "timeout": 300
+      },
+      "dependencies": [
+        "dotnet-sdk-6.0",
+        "mono-complete"
+      ],
+      "source": "https://github.com/mono/mgcb-editor",
+      "license": "MIT",
+      "documentation": "https://docs.monogame.net/articles/tools/mgcb_editor.html",
+      "installScript": "dotnet tool install --global dotnet-mgcb-editor-windows --version 3.8.2.1105",
+      "compatibleWith": {
+        "dotnet": ">=6.0",
+        "monogame": ">=3.8"
+      }
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.2.1105",
+      "commands": [
+        {
+          "name": "mgcb-editor-linux",
+          "description": "Launches the MGCB Editor for Linux"
+        }
+      ],
+      "rollForward": false,
+      "options": {
+        "verbose": true,
+        "timeout": 300
+      },
+      "dependencies": [
+        "dotnet-sdk-6.0",
+        "mono-complete"
+      ],
+      "source": "https://github.com/mono/mgcb-editor",
+      "license": "MIT",
+      "documentation": "https://docs.monogame.net/articles/tools/mgcb_editor.html",
+      "installScript": "dotnet tool install --global dotnet-mgcb-editor-linux --version 3.8.2.1105",
+      "compatibleWith": {
+        "dotnet": ">=6.0",
+        "monogame": ">=3.8"
+      }
     }
   }
 }


### PR DESCRIPTION
New Tool: "dotnet-mgcb-editor-linux"
Mirrors the Windows tool with a Linux-specific command, supporting multi-platform development.

Enhanced "commands"
Changed from a simple string array to an array of objects, each with a "name" and "description", improving clarity.

"options"
Adds "verbose": true for detailed output and "timeout": 300 (seconds) as an example setting, enhancing configurability.

"dependencies"
Lists "dotnet-sdk-6.0" and "mono-complete" as prerequisites, ensuring the environment is properly set up.

"source"
Provides a GitHub URL, assumed for the MGCB Editor, linking to its origin.

"license"
Specifies "MIT", a common license for MonoGame tools, for legal clarity.

"documentation"
Links to MonoGame’s MGCB Editor docs, aiding user onboarding.

"installScript"
Offers a dotnet tool install command tailored to each tool, simplifying installation.

"compatibleWith"
Specifies minimum versions of .NET and MonoGame, ensuring compatibility.